### PR TITLE
Fix spec_helper

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,7 @@
 require 'bundler/setup'
 require 'thingsboard'
 require 'faraday'
+require 'active_support'
 require 'active_support/core_ext/string'
 require 'active_support/core_ext/hash/indifferent_access'
 require 'active_support/core_ext/securerandom'


### PR DESCRIPTION
This will require 'active_support' in spec helper to make the specs run again.
This issue was introduced by merging https://github.com/ioki-mobility/thingsboard-ruby/pull/56 although the PR itself was green.